### PR TITLE
Allows OpenSRP to Use the Loopback Address

### DIFF
--- a/charts/opensrp-server-web/Chart.yaml
+++ b/charts/opensrp-server-web/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensrp-server-web/templates/deployment.yaml
+++ b/charts/opensrp-server-web/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
     {{- include "opensrp-server-web.selectorLabels" . | nindent 8 }}
     spec:
+      hostNetwork: true
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Allows the OpenSRP container to use the loopback address when contacting Keycloak to
allow us set `ssl-required: "external"` in the keycloak_json configuration.