### PR TITLE
Adds Support for Rendering Latest Chart Versions

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -27,6 +27,38 @@ jobs:
           version: v3.5.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1.2.0 # step that writes the latest chart versions (below) depends on this step writing the latest version as the first index in the entries.<name of chart> list in the index.yaml file
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Install Python
+        uses: actions/setup-python@v1
+
+      - name: Install pip requirements
+        uses: BSFishy/pip-action@v1
+        with:
+          packages: |
+            shyaml==0.6.2
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: gh-pages
+
+      - name: Record the latest chart versions
+        run: |
+          releaseDir="latest"
+          if [[ ! -d ${releaseDir} ]]; then
+            mkdir -p ${releaseDir}
+          fi
+          charts=($(cat index.yaml | shyaml keys entries))
+          for curChart in "${charts[@]}"; do
+            curChartVersion=$(cat index.yaml | shyaml get-value entries.${curChart}.0.version)
+            echo ${curChartVersion} > ${releaseDir}/${curChart}
+          done
+
+      - uses: EndBug/add-and-commit@v7
+        with:
+          message: 'Set the latest the chart versions'
+          branch: gh-pages


### PR DESCRIPTION
Add support for rendering the latest chart version for each of the
charts in `https://helm.smartregister.org/latest/<name of chart>`

This will allow continuous delivery pipelines to only fire when the
charts they use are updated, instead of when any of the charts are
updated.

Effort: 1:00 hours

Signed-off-by: Jason Rogena <jason@rogena.me>