### PR TITLE
Adds the VPA for OpenSRP Server Web Chart

### DIFF
--- a/charts/opensrp-server-web/Chart.yaml
+++ b/charts/opensrp-server-web/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensrp-server-web/README.md
+++ b/charts/opensrp-server-web/README.md
@@ -209,6 +209,8 @@ The following table lists the configurable parameters of the Opensrp-server-web 
 | `nodeSelector` |  | `{}` |  
 | `tolerations` |  | `[]` |  
 | `affinity` |  | `{}` |  
+| `vpa.enabled` | `Whether to enable vertical pod autoscaling` | `true` |
+| `vpa.updatePolicy` | `The update policy to use with the vertical pod autoscaler` | `updateMode: "Off"` |
 
 ## Opensrp Server Web  Parameters
 | Parameter                | Description             | Default        |  

--- a/charts/opensrp-server-web/templates/vpa.yaml
+++ b/charts/opensrp-server-web/templates/vpa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "opensrp-server-web.fullname" . }}
+  labels:
+    {{- include "opensrp-server-web.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: {{ include "opensrp-server-web.fullname" . }}
+  updatePolicy:
+    {{- toYaml .Values.vpa.updatePolicy | nindent 4 }}
+  {{- if .Values.vpa.resourcePolicy }}
+  resourcePolicy:
+    {{- toYaml .Values.vpa.resourcePolicy | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/opensrp-server-web/values.yaml
+++ b/charts/opensrp-server-web/values.yaml
@@ -279,3 +279,9 @@ multimediaPvc:
   accessModes:
     - ReadWriteOnce
   selector: {}
+
+vpa:
+  enabled: true
+  updatePolicy:
+    updateMode: "Off"
+  resourcePolicy: {}


### PR DESCRIPTION
Add the Vertical Pod Autoscaler to the OpenSRP Server Web Helm chart to
help with figuring out what the resource requests and limits should be
for the service.

Effort: 1:00 hours

Signed-off-by: Jason Rogena <jason@rogena.me>