### PR TITLE
add default sentry configurations

### DIFF
--- a/charts/hapi-fhir/Chart.yaml
+++ b/charts/hapi-fhir/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v5.4.1"
+appVersion: "v5.8.0"

--- a/charts/hapi-fhir/README.md
+++ b/charts/hapi-fhir/README.md
@@ -69,3 +69,24 @@ The following table lists the configurable parameters of the Hapi-fhir chart and
 | `commonLabels` |  | `{}` |  
 | `vpa.enabled` | `Whether to enable vertical pod autoscaling` | `true` |
 | `vpa.updatePolicy` | `The update policy to use with the vertical pod autoscaler` | `updateMode: "Off"` |
+
+## Sentry Configuration
+Sentry logging has been added to opensrp/hapi-fhir-jpaserver-starter [v5.8.0](https://github.com/opensrp/hapi-fhir-jpaserver-starter/releases/tag/v5.8.0-SNAPSHOT). To enable it update the following configurations:
+```yaml
+applicationConfig:
+  ...
+  sentry:
+    enabled: true
+    options:
+      dsn: https://valid-sentry-dsn
+      release: "{{ .Values.image.tag }}"
+      environment: staging
+      tags: '{{ include "hapi-fhir.sentryTags" . }}' # Only modify if one does not need release name and namespace tags. 
+      additionalTags: 
+#        key: value
+      debug: false
+    minimumEventLevel: ERROR
+    minimumBreadcrumbLevel: INFO
+ ...
+```
+The default sentry tags are `release-namespace` and `release-name` obtained from .Release.Namespace and .Release.Name respectively. To add on the default tags include the new tags under `additionalTags`. 

--- a/charts/hapi-fhir/templates/_helpers.tpl
+++ b/charts/hapi-fhir/templates/_helpers.tpl
@@ -75,3 +75,14 @@ Populate the pod annotations
 checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- end }}
 {{- end }}
+
+{{/*
+Build sentry tags
+*/}}
+{{- define "hapi-fhir.sentryTags" }}
+{{- $dynamicTagMap := dict "release-name" (.Release.Name) "release-namespace" (.Release.Namespace) -}}
+{{- range $index, $element:=.Values.applicationConfig.sentry.options.additionalTags }}
+{{- $_ := set $dynamicTagMap $index $element -}}
+{{- end }}
+{{- $dynamicTagMap | toJson }}
+{{- end }}

--- a/charts/hapi-fhir/values.yaml
+++ b/charts/hapi-fhir/values.yaml
@@ -140,6 +140,19 @@ applicationConfig:
 #          server_address: "http://hapi.fhir.org/baseR4"
 #          refuse_to_fetch_third_party_urls: false
 #          fhir_version: R4
+#
+#  sentry:
+#    enabled: false
+#    options:
+#      dsn:
+#      release:  "{{ .Values.image.tag }}"
+#      environment: staging
+#      tags: '{{ include "hapi-fhir.sentryTags" . }}'
+#      additionalTags:
+##        key: value
+#      debug: false
+#    minimumEventLevel: ERROR
+#    minimumBreadcrumbLevel: INFO
 
 vpa:
   enabled: true


### PR DESCRIPTION
Add `release-namespace` and `release-name` as default sentry tags.