### PR TITLE
remove metric ip subnet config

### DIFF
--- a/charts/opensrp-server-web/Chart.yaml
+++ b/charts/opensrp-server-web/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensrp-server-web/Chart.yaml
+++ b/charts/opensrp-server-web/Chart.yaml
@@ -18,9 +18,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v3.0.11-SNAPSHOT
+appVersion: v3.1.3-SNAPSHOT

--- a/charts/opensrp-server-web/README.md
+++ b/charts/opensrp-server-web/README.md
@@ -339,7 +339,6 @@ The following table lists the configurable parameters of the Opensrp-server-web 
 | `health.endpoint.keycloak.readTimeout` |  | `null` |
 | `metrics.health_check_updater.cron` |  | `"0 0/1 * * * *"` |
 | `metrics.tags` |  | `null` |
-| `metrics.additional_ip_allowed_octet` |  | `16` |
 | `metrics.additional_ip_allowed` |  | `null` |
 | `metrics.include` |  | `"all"` |
 | `metrics.exclude` |  | `null` |

--- a/charts/opensrp-server-web/templates/_helpers.tpl
+++ b/charts/opensrp-server-web/templates/_helpers.tpl
@@ -110,15 +110,6 @@ Find the metricsAdditionalIpAllowedPattern
 */}}
 {{- define "opensrp-server-web.metricsAdditionalIpAllowed"  -}}
 {{- if not .Values.metrics.permitAll -}}
-{{- $ipPatternAllowed := .Values.metrics.additional_ip_allowed -}}
-{{- if empty $ipPatternAllowed -}}
-{{- $node := (lookup "v1" "Node" .Release.Namespace "") -}}
-{{- if and $node $node.items -}}
-{{- $firstNode := ($node.items | first) -}}
-{{- $ipPatternAllowed =  (regexFind  (repeat 4 "\\d{1,3}." | trimSuffix ".") $firstNode.spec.podCIDR ) -}}
-{{- $ipPatternAllowed = nospace (cat $ipPatternAllowed  "/" .Values.metrics.additional_ip_allowed_octet) -}}
-{{- end }}
-{{- end }}
-{{- $ipPatternAllowed -}}
+{{- .Values.metrics.additional_ip_allowed -}}
 {{- end }}
 {{- end }}

--- a/charts/opensrp-server-web/values.yaml
+++ b/charts/opensrp-server-web/values.yaml
@@ -307,14 +307,11 @@ health:
       readTimeout:
 
 # metrics configurations
-# if additional_ip_allowed not specified it defaults to first podCIDR subnet with new subnet of /additional_ip_allowed_octet
-# assumption here is that all nodes PodCIDRS can belong in the same subnet
-# permitAll will ignore additional_ip_allowed and additional_ip_allowed_octet and permit all ips, Kindly add ingress config to block the metrics endpoint
+# permitAll will ignore additional_ip_allowed and permit all ips, Kindly add ingress config to block the metrics endpoint
 metrics:
   health_check_updater:
     cron: "0 0/1 * * * *"
   tags:
-  additional_ip_allowed_octet: 16
   additional_ip_allowed:
   include: "all"
   exclude:


### PR DESCRIPTION
Removes generation of ip subnet for ips allowed to access metrics endpoint. Its not reliable.