### PR TITLE
Adds tomcat host valve config

### DIFF
--- a/charts/opensrp-server-web/Chart.yaml
+++ b/charts/opensrp-server-web/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensrp-server-web/README.md
+++ b/charts/opensrp-server-web/README.md
@@ -350,6 +350,9 @@ The following table lists the configurable parameters of the Opensrp-server-web 
 | `thread.pool.coreSize` |  | `50` |
 | `thread.pool.maxSize` |  | `100` |
 | `thread.pool.queueCapacity` |  | `250` |
+| `tomcatHostValves.ErrorReportValve.className` |  | `"org.apache.catalina.valves.ErrorReportValve"` |
+| `tomcatHostValves.ErrorReportValve.showReport` |  | `false` |
+| `tomcatHostValves.ErrorReportValve.showServerInfo` |  | `false` |
 
 ## Multimedia Storage
 By default, multimedia (patient images, csv import files, e.t.c) collected on the opensrp server are stored on an S3 bucket. The S3 credentials have the following configurations:

--- a/charts/opensrp-server-web/templates/_helpers.tpl
+++ b/charts/opensrp-server-web/templates/_helpers.tpl
@@ -113,3 +113,16 @@ Find the metricsAdditionalIpAllowedPattern
 {{- .Values.metrics.additional_ip_allowed -}}
 {{- end }}
 {{- end }}
+
+{{/*
+Build tomcat host valves
+*/}}
+{{- define "opensrp-server-web.tomcatHostValves"  -}}
+{{- range $valve:=.Values.tomcatHostValves }}
+<Valve
+{{- range $valvePropertyKey, $valvePropertyValue:=$valve }}
+{{ $valvePropertyKey }}={{ $valvePropertyValue | quote -}}
+{{- end -}}
+/>
+{{- end }}
+{{- end }}

--- a/charts/opensrp-server-web/templates/config/opensrp/_server.xml.tpl
+++ b/charts/opensrp-server-web/templates/config/opensrp/_server.xml.tpl
@@ -1,0 +1,42 @@
+
+{{- define "config.opensrp.server.xml" }}
+<?xml version="1.0" encoding="UTF-8"?>
+<Server port="8005" shutdown="SHUTDOWN">
+    <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+    <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+    <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+    <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+    <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+    <GlobalNamingResources>
+        <Resource name="UserDatabase" auth="Container"
+                  type="org.apache.catalina.UserDatabase"
+                  description="User database that can be updated and saved"
+                  factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+                  pathname="conf/tomcat-users.xml" />
+    </GlobalNamingResources>
+    <Service name="Catalina">
+        <Connector port="8080" protocol="HTTP/1.1"
+                   connectionTimeout="20000"
+                   redirectPort="8443" />
+        <Engine name="Catalina" defaultHost="localhost">
+            <Realm className="org.apache.catalina.realm.LockOutRealm">
+                <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+                       resourceName="UserDatabase"/>
+            </Realm>
+
+            <Host name="localhost"  appBase="webapps"
+                  unpackWARs="true" autoDeploy="true">
+
+                {{ include "opensrp-server-web.tomcatHostValves" . }}
+
+                <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+                       prefix="localhost_access_log" suffix=".txt"
+                       pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+            </Host>
+        </Engine>
+    </Service>
+</Server>
+
+{{- end }}

--- a/charts/opensrp-server-web/templates/configmap.yaml
+++ b/charts/opensrp-server-web/templates/configmap.yaml
@@ -15,3 +15,5 @@ data:
     {{- include "config.mybatis.deployment.properties" . | nindent 4 }}
   opensrp.web.xml: |
     {{- include "config.opensrp.web.xml" . | indent 4 }}
+  opensrp.server.xml: |
+    {{- include "config.opensrp.server.xml" . | indent 4 }}

--- a/charts/opensrp-server-web/templates/deployment.yaml
+++ b/charts/opensrp-server-web/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         - name: opensrp-server-config-web
           configMap:
             name: {{ include "opensrp-server-web.fullname" . }}
+        - name: opensrp-server-config-server-xml
+          configMap:
+            name: {{ include "opensrp-server-web.fullname" . }}
         {{- if .Values.multimediaPvc.enabled }}
         - name: opensrp-server-multimedia-dir
           persistentVolumeClaim:
@@ -79,6 +82,9 @@ spec:
             - name: opensrp-server-config-web
               mountPath: /usr/local/tomcat/webapps/opensrp/WEB-INF/web.xml
               subPath: opensrp.web.xml
+            - name: opensrp-server-config-server-xml
+              mountPath: /usr/local/tomcat/conf/server.xml
+              subPath: opensrp.server.xml
               {{- if .Values.multimediaPvc.enabled }}
             - name: opensrp-server-multimedia-dir
               mountPath: /opt/multimedia

--- a/charts/opensrp-server-web/values.yaml
+++ b/charts/opensrp-server-web/values.yaml
@@ -332,3 +332,11 @@ pdb:
   enabled: false
   minAvailable: ""
   maxUnavailable: 1
+
+# Tomcat valves to be placed under the host section on the server.xml
+# By default ErrorReportValve is added to hide stacktrace returned with HTML response for security reasons. Read more here https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html.
+tomcatHostValves:
+  ErrorReportValve:
+    className: org.apache.catalina.valves.ErrorReportValve
+    showReport: false
+    showServerInfo: false


### PR DESCRIPTION
- Enables one to dynamically add tomcat valves inside the host tag in server.xml.
   - By default ErrorReportValve is added to prevent stacktrace from being returned by HTML response.

Read more below https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html