### PR TITLE
make mybatis version configurable

### DIFF
--- a/charts/opensrp-server-web/Chart.yaml
+++ b/charts/opensrp-server-web/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensrp-server-web/README.md
+++ b/charts/opensrp-server-web/README.md
@@ -239,6 +239,10 @@ The following table lists the configurable parameters of the Opensrp-server-web 
 | `mybatis.schedule_tablespace` |  | `"pg_default"` |
 | `mybatis.feed_tablespace` |  | `"pg_default"` |
 | `mybatis.form_tablespace` |  | `"pg_default"` |
+| `mybatis.resources.requests.memory` |  | `"50Mi"` |
+| `mybatis.resources.limits.memory` |  | `"100Mi"` |
+| `mybatis.resources.requests.cpu` |  | `"11m"` |
+| `mybatis.version` |  | `"3.3.4"` |
 | `opensrp.sms_can_be_sent` |  | `false` |
 | `opensrp.number_of_audit_messages` |  | `1000` |
 | `opensrp.use_opensrp_team_module` |  | `false` |
@@ -343,9 +347,6 @@ The following table lists the configurable parameters of the Opensrp-server-web 
 | `metrics.include` |  | `"all"` |
 | `metrics.exclude` |  | `null` |
 | `metrics.permitAll` |  | `false` |
-| `mybatis.resources.requests.memory` |  | `"50Mi"` |
-| `mybatis.resources.limits.memory` |  | `"100Mi"` |
-| `mybatis.resources.requests.cpu` |  | `"11m"` |
 | `env` |  | `""` |
 | `thread.pool.coreSize` |  | `50` |
 | `thread.pool.maxSize` |  | `100` |

--- a/charts/opensrp-server-web/templates/deployment.yaml
+++ b/charts/opensrp-server-web/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: opensrp-server-mybatis-properties
               mountPath: /migrations/environments/deployment.properties
               subPath: mybatis.properties
-          command: ["/opt/mybatis/mybatis-migrations-3.3.4/bin/migrate", "up", "--path=/migrations", "--env=deployment"]
+          command: ["/opt/mybatis/mybatis-migrations-{{ .Values.mybatis.version }}/bin/migrate", "up", "--path=/migrations", "--env=deployment"]
           resources:
       {{- toYaml .Values.mybatis.resources | nindent 12 }}
       containers:

--- a/charts/opensrp-server-web/values.yaml
+++ b/charts/opensrp-server-web/values.yaml
@@ -128,6 +128,7 @@ mybatis:
       memory: "50Mi"
     limits:
       memory: "100Mi"
+  version: 3.3.4
 
 opensrp:
   sms_can_be_sent: false


### PR DESCRIPTION
- Make mybatis version configurable i.e 3.3.4 or 3.3.9.
 
**NOTE:**
- This is a [security vulnerability fix](https://nvd.nist.gov/vuln/detail/CVE-2020-26945).
- On chart version 0.7.x the version will be 3.3.9 or above by default i.e assuming [mybatis runtime](https://github.com/opensrp/opensrp-server-web/issues/1088) has not been integrated yet. 